### PR TITLE
AT-408: Add "always up" ability to migration tool

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -12,11 +12,14 @@ used for them.  `migrate` expects the filenames of migrations to have the format
 
     {version}_{title}.up.{extension}
     {version}_{title}.down.{extension}
+    {version}_{title}.alwaysup.{extension}
+    {version}_{title}.alwaysdown.{extension}
 
 The `title` of each migration is unused, and is only for readability.  Similarly,
 the `extension` of the migration files is not checked by the library, and should
 be an appropriate format for the database in use (`.sql` for SQL variants, for
-instance).
+instance). The `always` designation will run the migration file each time. This
+is useful for stored procedure and custom type definitions.
 
 Versions of migrations may be represented as any 64 bit unsigned integer.
 All migrations are applied upward in order of increasing version number, and

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Each migration has an up and down migration. [Why?](FAQ.md#why-two-separate-file
 ```bash
 1481574547_create_users_table.up.sql
 1481574547_create_users_table.down.sql
+1481574547_stored_procs.alwaysup.sql
+1481574547_stored_procs.alwaysdown.sql
 ```
 
 [Best practices: How to write migrations.](MIGRATIONS.md)

--- a/database/postgres/examples/migrations/1885849761_always_comment.alwaysup.sql
+++ b/database/postgres/examples/migrations/1885849761_always_comment.alwaysup.sql
@@ -1,0 +1,1 @@
+-- Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean sed interdum velit, tristique iaculis justo. Pellentesque ut porttitor dolor. Donec sit amet pharetra elit. Cras vel ligula ex. Phasellus posuere.

--- a/migrate.go
+++ b/migrate.go
@@ -735,10 +735,13 @@ func (m *Migrate) runMigrations(ret <-chan interface{}) error {
 
 		case *Migration:
 			migr := r
+			once := r.Direction == source.Up || r.Direction == source.Down
 
 			// set version with dirty state
-			if err := m.databaseDrv.SetVersion(migr.TargetVersion, true); err != nil {
-				return err
+			if once {
+				if err := m.databaseDrv.SetVersion(migr.TargetVersion, true); err != nil {
+					return err
+				}
 			}
 
 			if migr.Body != nil {
@@ -749,8 +752,10 @@ func (m *Migrate) runMigrations(ret <-chan interface{}) error {
 			}
 
 			// set clean state
-			if err := m.databaseDrv.SetVersion(migr.TargetVersion, false); err != nil {
-				return err
+			if once {
+				if err := m.databaseDrv.SetVersion(migr.TargetVersion, false); err != nil {
+					return err
+				}
 			}
 
 			endTime := time.Now()

--- a/source/migration.go
+++ b/source/migration.go
@@ -8,8 +8,10 @@ import (
 type Direction string
 
 const (
-	Down Direction = "down"
-	Up   Direction = "up"
+	Down       Direction = "down"
+	Up         Direction = "up"
+	AlwaysUp   Direction = "alwaysup"
+	AlwaysDown Direction = "alwaysdown"
 )
 
 // Migration is a helper struct for source drivers that need to
@@ -101,6 +103,9 @@ func (i *Migrations) Up(version uint) (m *Migration, ok bool) {
 		if mx, ok := i.migrations[version][Up]; ok {
 			return mx, true
 		}
+		if mx, ok := i.migrations[version][AlwaysUp]; ok {
+			return mx, true
+		}
 	}
 	return nil, false
 }
@@ -108,6 +113,11 @@ func (i *Migrations) Up(version uint) (m *Migration, ok bool) {
 func (i *Migrations) Down(version uint) (m *Migration, ok bool) {
 	if _, ok := i.migrations[version]; ok {
 		if mx, ok := i.migrations[version][Down]; ok {
+			return mx, true
+		}
+	}
+	if _, ok := i.migrations[version]; ok {
+		if mx, ok := i.migrations[version][AlwaysDown]; ok {
 			return mx, true
 		}
 	}

--- a/source/migration.go
+++ b/source/migration.go
@@ -25,7 +25,7 @@ type Migration struct {
 	// this migration in the source.
 	Identifier string
 
-	// Direction is either Up or Down.
+	// Direction is either Up, Down, AlwaysUp, or AlwaysDown.
 	Direction Direction
 
 	// Raw holds the raw location path to this migration in source.

--- a/source/parse.go
+++ b/source/parse.go
@@ -18,7 +18,9 @@ var (
 // Regex matches the following pattern:
 //  123_name.up.ext
 //  123_name.down.ext
-var Regex = regexp.MustCompile(`^([0-9]+)_(.*)\.(` + string(Down) + `|` + string(Up) + `)\.(.*)$`)
+//  123_name.alwaysup.ext
+//  123_name.alwaysdown.ext
+var Regex = regexp.MustCompile(`^([0-9]+)_(.*)\.(` + string(Down) + `|` + string(Up) + `|` + string(AlwaysDown) + `|` + string(AlwaysUp) + `)\.(.*)$`)
 
 // Parse returns Migration for matching Regex pattern.
 func Parse(raw string) (*Migration, error) {

--- a/source/parse_test.go
+++ b/source/parse_test.go
@@ -31,6 +31,26 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:      "1_foobar.alwaysup.sql",
+			expectErr: nil,
+			expectMigration: &Migration{
+				Version:    1,
+				Identifier: "foobar",
+				Direction:  AlwaysUp,
+				Raw:        "1_foobar.alwaysup.sql",
+			},
+		},
+		{
+			name:      "1_foobar.alwaysdown.sql",
+			expectErr: nil,
+			expectMigration: &Migration{
+				Version:    1,
+				Identifier: "foobar",
+				Direction:  AlwaysDown,
+				Raw:        "1_foobar.alwaysdown.sql",
+			},
+		},
+		{
 			name:      "1_f-o_ob+ar.up.sql",
 			expectErr: nil,
 			expectMigration: &Migration{


### PR DESCRIPTION
- Add an `AlwaysUp` and `AlwaysDown` direction constant to `source` package.
- Update the filename parse regex to detect these new direction constants.
- Alter the `Up` and `Down` behavior to include the always versions in migrations returned for execution.
- Created a sample `alwaysup` migration in postgres for testing purposes.
- Add `Direction` as field to `migrate.Migration` struct. Populate the field during `NewMigration()` process. Use the field to skip setting the version in the database if the direction is an `always`.
- Update documentation to outline the availability of always up functionality.

