### PR TITLE
AT-1061: Setup automated process to build and push to artifactory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,54 +3,60 @@
 # Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2.1
 
-jobs:
-  "golang-1_15": &template
-    machine:
-      # https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
-      image: ubuntu-2004:202010-01
-      # docker_layer_caching: true
+executors:
+  golang-1_16:
+    docker:
+      - image: cimg/go:1.16
 
-    # https://circleci.com/docs/2.0/configuration-reference/#resource_class
-    resource_class: medium
+orbs:
+  goreleaser: hubci/goreleaser@1.0
+  artifactory: circleci/artifactory@1.0.0
 
-    # Leave working directory unspecified and use defaults:
-    # https://circleci.com/blog/go-v1.11-modules-and-circleci/
-    # working_directory: /go/src/github.com/golang-migrate/migrate
-
-    environment:
-      GO111MODULE: "on"
-      GO_VERSION: "1.15.x"
-
+commands:
+  setup_goenv:
     steps:
-      # - setup_remote_docker:
-      #    version: 19.03.13
-          # docker_layer_caching: true
-      - run: curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
-      - run: curl -sfL -o ~/bin/golangci-lint.sh https://install.goreleaser.com/github.com/golangci/golangci-lint.sh
-      - run: chmod +x ~/bin/gimme ~/bin/golangci-lint.sh
-      - run: eval "$(gimme $GO_VERSION)"
-      - run: golangci-lint.sh -b ~/bin v1.37.0
-      - checkout
-      - restore_cache:
-          keys:
-            - go-mod-v1-{{ arch }}-{{ checksum "go.sum" }}
-      - run: golangci-lint run
-      - run: make test COVERAGE_DIR=/tmp/coverage
-      - save_cache:
-          key: go-mod-v1-{{ arch }}-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
-      - run: go get github.com/mattn/goveralls
-      - run: goveralls -service=circle-ci -coverprofile /tmp/coverage/combined.txt
+      - run:
+          name: configure go environment
+          command: |
+            go env -w GOPROXY="https://circleci:${ARTIFACTORY_APIKEY}@hqo.jfrog.io/artifactory/api/go/go,direct"
+            go env -w GOPRIVATE="github.com/HqOapp/*"
+            go env -w GONOSUMDB="github.com/HqOapp/*"
+            go env -w GO111MODULE="auto"
 
-  "golang-1_16":
-    <<: *template
-    environment:
-      GO_VERSION: "1.16.x"
+jobs:
+  build_and_push_image:
+    executor: golang-1_16
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - '68:84:cc:68:92:f5:2c:71:7f:8b:05:01:0b:b5:4a:de' # This is the global HqO github ssh key
+      - setup_remote_docker:
+          docker_layer_caching: true
+          context: artifactory
+      - checkout
+      - artifactory/install
+      - artifactory/docker-login:
+          artifactory-key: ARTIFACTORY_APIKEY
+          docker-registry: hqo-docker.jfrog.io
+      - goreleaser/install:
+          version: '0.173.2'
+      - setup_goenv
+      - run:
+          name: Build migrate binary and docker image
+          command: goreleaser --snapshot --skip-publish --rm-dist
+      - run:
+          name: Publish migrate image with commit hash tag
+          command: docker push hqo-docker.jfrog.io/migrate:$CIRCLE_SHA1
+      - when: # master branch
+          condition:
+            equal: [master, << pipeline.git.branch >>]
+          steps:
+            - run:
+                name: Publish latest migrate image
+                command: docker push hqo-docker.jfrog.io/migrate:latest
 
 workflows:
   version: 2
   build:
     jobs:
-      - "golang-1_15"
-      - "golang-1_16"
+      - build_migrate_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,8 @@ jobs:
   build_and_push_image:
     executor: golang-1_16
     environment: 
-      DATABASE=""
-      SOURCE=""
+      database: ""
+      source: ""
     steps:
       - setup_remote_docker:
           docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ executors:
       - image: cimg/go:1.16
 
 orbs:
+  goreleaser: hubci/goreleaser@1.0
   artifactory: circleci/artifactory@1.0.0
   gotools: gotest/tools@0.0.13
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ commands:
             go env -w GOPRIVATE="github.com/HqOapp/*"
             go env -w GONOSUMDB="github.com/HqOapp/*"
             go env -w GO111MODULE="auto"
-            go env -w DATABASE=""
-            go env -w SOURCE=""
+            export DATABASE=""
+            export SOURCE=""
 
 jobs:
   build_and_push_image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ executors:
 orbs:
   goreleaser: hubci/goreleaser@1.0
   artifactory: circleci/artifactory@1.0.0
+  gotools: gotest/tools@0.0.13
 
 commands:
   setup_goenv:
@@ -29,7 +30,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - '68:84:cc:68:92:f5:2c:71:7f:8b:05:01:0b:b5:4a:de' # This is the global HqO github ssh key
+            - '40:e0:40:c0:03:ab:27:c7:e1:94:cb:1e:b4:27:83:f1'
       - setup_remote_docker:
           docker_layer_caching: true
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
     executor: golang-1_16
     steps:
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - checkout
       - artifactory/install
       - artifactory/docker-login:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ executors:
       - image: cimg/go:1.16
 
 orbs:
-  goreleaser: hubci/goreleaser@1.0
   artifactory: circleci/artifactory@1.0.0
   gotools: gotest/tools@0.0.13
 
@@ -36,7 +35,7 @@ jobs:
           artifactory-key: ARTIFACTORY_APIKEY
           docker-registry: hqo-docker.jfrog.io
       - goreleaser/install:
-          version: '0.173.2'
+          version: '1.8.3'
       - setup_goenv
       - run:
           name: Build migrate binary and docker image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,6 @@ jobs:
       - run:
           name: Build & Tag Migrate Image
           command: docker build . -t hqo-docker.jfrog.io/migrate:$CIRCLE_SHA1 -t hqo-docker.jfrog.io/migrate:latest --progress=plain
-          environment:
-            DOCKER_BUILDKIT: 1
       - run:
           name: Publish migrate image with commit hash tag
           command: docker push hqo-docker.jfrog.io/migrate:$CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,6 @@ commands:
 jobs:
   build_and_push_image:
     executor: golang-1_16
-    environment: 
-      database: ""
-      source: ""
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
@@ -43,6 +40,9 @@ jobs:
       - setup_goenv
       - run:
           name: Build migrate binary and docker image
+          environment: 
+            DATABASE: ""
+            SOURCE: ""
           command: goreleaser --snapshot --skip-publish --rm-dist
       - run:
           name: Publish migrate image with commit hash tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ jobs:
             - '68:84:cc:68:92:f5:2c:71:7f:8b:05:01:0b:b5:4a:de' # This is the global HqO github ssh key
       - setup_remote_docker:
           docker_layer_caching: true
-          context: artifactory
       - checkout
       - artifactory/install
       - artifactory/docker-login:
@@ -59,4 +58,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - build_and_push_image
+      - build_and_push_image:
+          name: Build Migrate
+          context: artifactory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ executors:
       - image: cimg/go:1.16
 
 orbs:
-  goreleaser: hubci/goreleaser@1.0
   artifactory: circleci/artifactory@1.0.0
   gotools: gotest/tools@0.0.13
 
@@ -29,21 +28,17 @@ jobs:
     executor: golang-1_16
     steps:
       - setup_remote_docker:
-          docker_layer_caching: false
+          docker_layer_caching: true
       - checkout
       - artifactory/install
       - artifactory/docker-login:
           artifactory-key: ARTIFACTORY_APIKEY
           docker-registry: hqo-docker.jfrog.io
-      - goreleaser/install:
-          version: '1.8.3'
-      - setup_goenv
       - run:
-          name: Build migrate binary and docker image
-          environment: 
-            DATABASE: ""
-            SOURCE: ""
-          command: goreleaser --snapshot --skip-publish --rm-dist
+          name: Build & Tag Migrate Image
+          command: docker build . -t hqo-docker.jfrog.io/migrate:$CIRCLE_SHA1 -t hqo-docker.jfrog.io/migrate:latest --progress=plain
+          environment:
+            DOCKER_BUILDKIT: 1
       - run:
           name: Publish migrate image with commit hash tag
           command: docker push hqo-docker.jfrog.io/migrate:$CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,4 +59,4 @@ workflows:
   version: 2
   build:
     jobs:
-      - build_migrate_image
+      - build_and_push_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,12 +23,13 @@ commands:
             go env -w GOPRIVATE="github.com/HqOapp/*"
             go env -w GONOSUMDB="github.com/HqOapp/*"
             go env -w GO111MODULE="auto"
-            export DATABASE=""
-            export SOURCE=""
 
 jobs:
   build_and_push_image:
     executor: golang-1_16
+    environment: 
+      DATABASE=""
+      SOURCE=""
     steps:
       - setup_remote_docker:
           docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,14 +23,13 @@ commands:
             go env -w GOPRIVATE="github.com/HqOapp/*"
             go env -w GONOSUMDB="github.com/HqOapp/*"
             go env -w GO111MODULE="auto"
+            go env -w DATABASE=""
+            go env -w SOURCE=""
 
 jobs:
   build_and_push_image:
     executor: golang-1_16
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - '40:e0:40:c0:03:ab:27:c7:e1:94:cb:1e:b4:27:83:f1'
       - setup_remote_docker:
           docker_layer_caching: true
       - checkout


### PR DESCRIPTION
## What

- Update CircleCI config to automatically build and push an image of migrate to artifactory

## Why 

- So that the latest version of migrate is available for other repos to use

## References

- Link to ticket [here](https://ventureapp.atlassian.net/jira/software/c/projects/AT/boards/125?modal=detail&selectedIssue=AT-1061)